### PR TITLE
Mode shows “off” regardless of actual mode

### DIFF
--- a/Haier.h
+++ b/Haier.h
@@ -30,16 +30,6 @@ using namespace esphome::climate;
 #define SWING_OFF        0
 #define SWING_BOTH       1
 
-#define SWING_POS           31
-#define SWING_UNDEFINED     0
-#define SWING_HORIZONTAL    8
-#define SWING_VERTICAL      16
-// bit  >>
-#define TURBO_MODE_BIT_ON       1
-#define SILENT_MODE_BIT_ON      2
-#define SWING_HORIZONTAL_BIT    3
-#define SWING_VERTICAL_BIT      4
-
 #define LOCK                28
 #define LOCK_ON             80
 #define LOCK_OFF            00
@@ -48,14 +38,21 @@ using namespace esphome::climate;
 #define POWER_ON        1
 #define POWER_OFF       0
 // bit  >>
-#define POWER_BIT_ON        0
-#define HEALTH_MODE_BIT_ON  3
-#define XXXXX_MODE_BIT_ON   4
+#define POWER_BIT_ON             0
+#define HEALTH_MODE_BIT_ON       3
+#define COMPRESSOR_MODE_BIT_ON   4
 
-
-#define FRESH       31
-#define FRESH_ON    1
-#define FRESH_OFF   0
+#define SWING_POS           31
+#define SWING_UNDEFINED     0
+#define SWING_HORIZONTAL    8
+#define SWING_VERTICAL      16
+// bit  >>
+#define FRESH_BIT_ON            0
+#define TURBO_MODE_BIT_ON       1
+#define SILENT_MODE_BIT_ON      2
+#define SWING_HORIZONTAL_BIT    3
+#define SWING_VERTICAL_BIT      4
+#define LED_BIT_OFF             5
 
 #define SET_TEMPERATURE 35
 

--- a/Haier.h
+++ b/Haier.h
@@ -87,7 +87,7 @@ public:
 			
 			data[0] = 255;
 			data[1] = 255;
-			
+
             Serial.readBytes(data+2, sizeof(data)-2);
 
             readData();

--- a/Haier.h
+++ b/Haier.h
@@ -264,6 +264,7 @@ public:
                         data[SET_TEMPERATURE] = TEMPERATURE_FOR_FAN_ONLY;
                     }
                     data[POWER] |= (1 << POWER_BIT_ON);
+                    data[FAN_SPEED] = FAN_MIDDLE; // set fan speed for change work mode
                     data[MODE] = MODE_FAN_ONLY;
                     break;
                 case CLIMATE_MODE_AUTO:

--- a/Haier.h
+++ b/Haier.h
@@ -57,6 +57,7 @@ using namespace esphome::climate;
 #define MIN_SET_TEMPERATURE 16
 #define MAX_SET_TEMPERATURE 30
 #define STEP_TEMPERATURE 1
+#define TEMPERATURE_FOR_FAN_ONLY    8
 
 //if internal temperature is outside of those boundaries, message will be discarded
 #define MIN_VALID_INTERNAL_TEMP 10
@@ -257,6 +258,11 @@ public:
                     data[MODE] = MODE_DRY;
                     break;
                 case CLIMATE_MODE_FAN_ONLY:
+                    if (data[POWER] & ( 1 << POWER_BIT_ON )) {
+                        //ESP_LOGW("Haier", "Cold start");
+                    } else {
+                        data[SET_TEMPERATURE] = TEMPERATURE_FOR_FAN_ONLY;
+                    }
                     data[POWER] |= (1 << POWER_BIT_ON);
                     data[MODE] = MODE_FAN_ONLY;
                     break;
@@ -328,7 +334,6 @@ public:
         data[11] = 95;
 
         sendData(data, sizeof(data));
-
 
     }
 

--- a/Haier.h
+++ b/Haier.h
@@ -35,8 +35,10 @@ using namespace esphome::climate;
 #define SWING_HORIZONTAL    8
 #define SWING_VERTICAL      16
 // bit  >>
-#define SILENT_MODE_ON      4
-#define TURBO_MODE_ON       2
+#define TURBO_MODE_BIT_ON       1
+#define SILENT_MODE_BIT_ON      2
+#define SWING_HORIZONTAL_BIT    3
+#define SWING_VERTICAL_BIT      4
 
 #define LOCK                28
 #define LOCK_ON             80
@@ -45,13 +47,11 @@ using namespace esphome::climate;
 #define POWER           29
 #define POWER_ON        1
 #define POWER_OFF       0
-#define POWER_ON_1      9
-#define POWER_OFF_1     8
-#define POWER_ON_2      25
-#define POWER_OFF_2     24
 // bit  >>
-#define HEALTH_MODE_ON  8
-#define XXXXX_MODE_ON   16
+#define POWER_BIT_ON        0
+#define HEALTH_MODE_BIT_ON  3
+#define XXXXX_MODE_BIT_ON   4
+
 
 #define FRESH       31
 #define FRESH_ON    1
@@ -183,8 +183,10 @@ public:
         }
 
 
-        if (data[POWER] == POWER_OFF || data[POWER] == POWER_OFF_2) {
+        if (data[POWER] & ( 0 << POWER_BIT_ON )) {
             mode = CLIMATE_MODE_OFF;
+            fan_mode = CLIMATE_FAN_OFF;
+            swing_mode = CLIMATE_SWING_OFF;
 
         } else {
 
@@ -204,13 +206,6 @@ public:
                 default:
                     mode = CLIMATE_MODE_AUTO;
             }
-        }
-
-
-        if (data[POWER] == POWER_OFF || data[POWER] == POWER_OFF_1 || data[POWER] == POWER_OFF_2) {
-            fan_mode = CLIMATE_FAN_OFF;
-
-        } else {
 
             switch (data[FAN_SPEED]) {
                 case FAN_AUTO:
@@ -228,26 +223,15 @@ public:
                 default:
                     fan_mode = CLIMATE_FAN_AUTO;
             }
-        }
 
-
-        if (data[POWER] == POWER_OFF || data[POWER] == POWER_OFF_2) {
-            swing_mode = CLIMATE_SWING_OFF;
-
-        } else {
             switch (data[SWING]) {
-                case SWING_OFF: {
-                    switch (data[SWING_POS]) {
-                        case SWING_VERTICAL:
-                            swing_mode = CLIMATE_SWING_VERTICAL;
-                            break;
-                        case SWING_HORIZONTAL:
-                            swing_mode = CLIMATE_SWING_HORIZONTAL;
-                            break;
-                        case SWING_UNDEFINED:
-                            swing_mode = CLIMATE_SWING_OFF;
-                            break;
-                        }
+                case SWING_OFF: 
+                    if ( data[SWING_POS] & ( 1 << SWING_VERTICAL_BIT )) {
+                        swing_mode = CLIMATE_SWING_VERTICAL;
+                    } else if ( data[SWING_POS] & ( 1 << SWING_HORIZONTAL_BIT )) {
+                        swing_mode = CLIMATE_SWING_HORIZONTAL;
+                    } else {
+                        swing_mode = CLIMATE_SWING_OFF;
                     }
                     break;
                 case SWING_BOTH:

--- a/Haier.h
+++ b/Haier.h
@@ -283,26 +283,31 @@ public:
                 case CLIMATE_FAN_LOW:
                     data[POWER] |= (1 << POWER_BIT_ON);
                     data[SWING_POS] |= (1 << SILENT_MODE_BIT_ON);
+                    data[SWING_POS] &= ~(1 << TURBO_MODE_BIT_ON);
                     break;
                 case CLIMATE_FAN_MIDDLE:
                     data[POWER] |= (1 << POWER_BIT_ON);
                     data[FAN_SPEED] = FAN_MIDDLE;
                     data[SWING_POS] &= ~(1 << SILENT_MODE_BIT_ON);
+                    data[SWING_POS] &= ~(1 << TURBO_MODE_BIT_ON);
                     break;
                 case CLIMATE_FAN_MEDIUM:
                     data[POWER] |= (1 << POWER_BIT_ON);
                     data[FAN_SPEED] = FAN_MEDIUM;
                     data[SWING_POS] &= ~(1 << SILENT_MODE_BIT_ON);
+                    data[SWING_POS] &= ~(1 << TURBO_MODE_BIT_ON);
                     break;
                 case CLIMATE_FAN_HIGH:
                     data[POWER] |= (1 << POWER_BIT_ON);
                     data[FAN_SPEED] = FAN_HIGH;
                     data[SWING_POS] &= ~(1 << SILENT_MODE_BIT_ON);
+                    data[SWING_POS] &= ~(1 << TURBO_MODE_BIT_ON);
                     break;
                 case CLIMATE_FAN_AUTO:
                     data[POWER] |= (1 << POWER_BIT_ON);
                     data[FAN_SPEED] = FAN_AUTO;
                     data[SWING_POS] &= ~(1 << SILENT_MODE_BIT_ON);
+                    data[SWING_POS] &= ~(1 << TURBO_MODE_BIT_ON);
                     break;
         }
 

--- a/Haier.h
+++ b/Haier.h
@@ -21,9 +21,9 @@ using namespace esphome::climate;
 #define MODE_DRY        4
 
 #define FAN_SPEED       25
-#define FAN_LOW         2
-#define FAN_MIDDLE      1
 #define FAN_HIGH        0
+#define FAN_MIDDLE      1
+#define FAN_MEDIUM      2
 #define FAN_AUTO        3
 
 #define SWING           27
@@ -128,7 +128,7 @@ protected:
         traits.set_supports_fan_mode_off(false);
         traits.set_supports_fan_mode_auto(true);
         traits.set_supports_fan_mode_low(true);
-        traits.set_supports_fan_mode_medium(false);
+        traits.set_supports_fan_mode_medium(true);
         traits.set_supports_fan_mode_middle(true);
         traits.set_supports_fan_mode_high(true);
         traits.set_supports_fan_mode_focus(false);
@@ -195,21 +195,25 @@ public:
                     mode = CLIMATE_MODE_AUTO;
             }
 
-            switch (data[FAN_SPEED]) {
-                case FAN_AUTO:
-                    fan_mode = CLIMATE_FAN_AUTO;
-                    break;
-                case FAN_LOW:
-                    fan_mode = CLIMATE_FAN_LOW;
-                    break;
-                case FAN_MIDDLE:
-                    fan_mode = CLIMATE_FAN_MIDDLE;
-                    break;
-                case FAN_HIGH:
-                    fan_mode = CLIMATE_FAN_HIGH;
-                    break;
-                default:
-                    fan_mode = CLIMATE_FAN_AUTO;
+            if ( data[SWING_POS] & ( 1 << SILENT_MODE_BIT_ON )) {
+                fan_mode = CLIMATE_FAN_LOW;
+            } else {
+                switch (data[FAN_SPEED]) {
+                    case FAN_AUTO:
+                        fan_mode = CLIMATE_FAN_AUTO;
+                        break;
+                    case FAN_MEDIUM:
+                        fan_mode = CLIMATE_FAN_MEDIUM;
+                        break;
+                    case FAN_MIDDLE:
+                        fan_mode = CLIMATE_FAN_MIDDLE;
+                        break;
+                    case FAN_HIGH:
+                        fan_mode = CLIMATE_FAN_HIGH;
+                        break;
+                    default:
+                        fan_mode = CLIMATE_FAN_AUTO;
+                }
             }
 
             switch (data[SWING]) {
@@ -278,19 +282,27 @@ public:
             switch(call.get_fan_mode().value()) {
                 case CLIMATE_FAN_LOW:
                     data[POWER] |= (1 << POWER_BIT_ON);
-                    data[FAN_SPEED] = FAN_LOW;
+                    data[SWING_POS] |= (1 << SILENT_MODE_BIT_ON);
                     break;
                 case CLIMATE_FAN_MIDDLE:
                     data[POWER] |= (1 << POWER_BIT_ON);
                     data[FAN_SPEED] = FAN_MIDDLE;
+                    data[SWING_POS] &= ~(1 << SILENT_MODE_BIT_ON);
+                    break;
+                case CLIMATE_FAN_MEDIUM:
+                    data[POWER] |= (1 << POWER_BIT_ON);
+                    data[FAN_SPEED] = FAN_MEDIUM;
+                    data[SWING_POS] &= ~(1 << SILENT_MODE_BIT_ON);
                     break;
                 case CLIMATE_FAN_HIGH:
                     data[POWER] |= (1 << POWER_BIT_ON);
                     data[FAN_SPEED] = FAN_HIGH;
+                    data[SWING_POS] &= ~(1 << SILENT_MODE_BIT_ON);
                     break;
                 case CLIMATE_FAN_AUTO:
                     data[POWER] |= (1 << POWER_BIT_ON);
                     data[FAN_SPEED] = FAN_AUTO;
+                    data[SWING_POS] &= ~(1 << SILENT_MODE_BIT_ON);
                     break;
         }
 

--- a/Haier.h
+++ b/Haier.h
@@ -10,44 +10,39 @@
 using namespace esphome;
 using namespace esphome::climate;
 
-#define TEMPERATURE   13
-#define COMMAND       17
+#define TEMPERATURE     13
+#define COMMAND         17
 
-#define MODE 23
-#define MODE_SMART 0
-#define MODE_COOL 1
-#define MODE_HEAT 2
-#define MODE_FAN_ONLY 3
-#define MODE_DRY 4
+#define MODE            23
+#define MODE_SMART      0
+#define MODE_COOL       1
+#define MODE_HEAT       2
+#define MODE_FAN_ONLY   3
+#define MODE_DRY        4
 
-#define FAN_SPEED   25
-#define FAN_LOW     2
-#define FAN_MIDDLE  1
-#define FAN_HIGH     0
-#define FAN_AUTO            3
+#define FAN_SPEED       25
+#define FAN_LOW         2
+#define FAN_MIDDLE      1
+#define FAN_HIGH        0
+#define FAN_AUTO        3
 
-#define SWING            27
-#define SWING_OFF        0
-#define SWING_BOTH       1
+#define SWING           27
+#define SWING_OFF       0
+#define SWING_BOTH      1
 
-#define LOCK                28
-#define LOCK_ON             80
-#define LOCK_OFF            00
+#define LOCK            28
+#define LOCK_ON         80
+#define LOCK_OFF        00
 
 #define POWER           29
-#define POWER_ON        1
-#define POWER_OFF       0
-// bit  >>
+// bit position  >>
 #define POWER_BIT_ON             0
 #define HEALTH_MODE_BIT_ON       3
 #define COMPRESSOR_MODE_BIT_ON   4
 
-#define SWING_POS           31
-#define SWING_UNDEFINED     0
-#define SWING_HORIZONTAL    8
-#define SWING_VERTICAL      16
-// bit  >>
-#define FRESH_BIT_ON            0
+#define SWING_POS               31
+// bit position >>
+#define SWING_UNDEFINED_BIT     0
 #define TURBO_MODE_BIT_ON       1
 #define SILENT_MODE_BIT_ON      2
 #define SWING_HORIZONTAL_BIT    3
@@ -247,26 +242,26 @@ public:
         if (call.get_mode().has_value())
             switch (call.get_mode().value()) {
                 case CLIMATE_MODE_OFF:
-                    data[POWER] = POWER_OFF;
+                    data[POWER] &= ~(1 << POWER_BIT_ON);
                     break;
                 case CLIMATE_MODE_COOL:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[MODE] = MODE_COOL;
                     break;
                 case CLIMATE_MODE_HEAT:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[MODE] = MODE_HEAT;
                     break;
                 case CLIMATE_MODE_DRY:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[MODE] = MODE_DRY;
                     break;
                 case CLIMATE_MODE_FAN_ONLY:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[MODE] = MODE_FAN_ONLY;
                     break;
                 case CLIMATE_MODE_AUTO:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[MODE] = MODE_SMART;
                     break;
             }
@@ -275,19 +270,19 @@ public:
         if (call.get_fan_mode().has_value())
             switch(call.get_fan_mode().value()) {
                 case CLIMATE_FAN_LOW:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[FAN_SPEED] = FAN_LOW;
                     break;
                 case CLIMATE_FAN_MIDDLE:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[FAN_SPEED] = FAN_MIDDLE;
                     break;
                 case CLIMATE_FAN_HIGH:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[FAN_SPEED] = FAN_HIGH;
                     break;
                 case CLIMATE_FAN_AUTO:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[FAN_SPEED] = FAN_AUTO;
                     break;
         }
@@ -297,24 +292,28 @@ public:
         if (call.get_swing_mode().has_value())
             switch(call.get_swing_mode().value()) {
                 case CLIMATE_SWING_OFF:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[SWING] = SWING_OFF;
-                    data[SWING_POS] = SWING_UNDEFINED;
+                    data[SWING_POS] &= ~(1 << SWING_UNDEFINED_BIT);
                     break;
                 case CLIMATE_SWING_VERTICAL:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[SWING] = SWING_OFF;
-                    data[SWING_POS] = SWING_VERTICAL;
+                    data[SWING_POS] |= (1 << SWING_VERTICAL_BIT);
+                    data[SWING_POS] &= ~(1 << SWING_HORIZONTAL_BIT);
                     break;
                 case CLIMATE_SWING_HORIZONTAL:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[SWING] = SWING_OFF;
-                    data[SWING_POS] = SWING_HORIZONTAL;
+                    data[SWING_POS] |= (1 << SWING_HORIZONTAL_BIT);
+                    data[SWING_POS] &= ~(1 << SWING_VERTICAL_BIT);
                     break;
                 case CLIMATE_SWING_BOTH:
-                    data[POWER] = POWER_ON;
+                    data[POWER] |= (1 << POWER_BIT_ON);
                     data[SWING] = SWING_BOTH;
-                    data[SWING_POS] = SWING_UNDEFINED;
+                    data[SWING_POS] &= ~(1 << SWING_UNDEFINED_BIT);
+                    data[SWING_POS] &= ~(1 << SWING_VERTICAL_BIT);
+                    data[SWING_POS] &= ~(1 << SWING_HORIZONTAL_BIT);
                     break;
         }
 

--- a/Haier.h
+++ b/Haier.h
@@ -183,12 +183,7 @@ public:
         }
 
 
-        if (data[POWER] & ( 0 << POWER_BIT_ON )) {
-            mode = CLIMATE_MODE_OFF;
-            fan_mode = CLIMATE_FAN_OFF;
-            swing_mode = CLIMATE_SWING_OFF;
-
-        } else {
+        if (data[POWER] & ( 1 << POWER_BIT_ON )) {
 
             switch (data[MODE]) {
                 case MODE_COOL:
@@ -237,7 +232,12 @@ public:
                 case SWING_BOTH:
                     swing_mode = CLIMATE_SWING_BOTH;
                     break;
-            }
+
+            } 
+        } else {
+            mode = CLIMATE_MODE_OFF;
+            //fan_mode = CLIMATE_FAN_OFF;
+            //swing_mode = CLIMATE_SWING_OFF;
         }
 
         this->publish_state();

--- a/Haier.h
+++ b/Haier.h
@@ -118,29 +118,42 @@ public:
 protected:
     ClimateTraits traits() override {
         auto traits = climate::ClimateTraits();
-        traits.set_supports_away(false);
-        traits.set_supports_auto_mode(true);
-        traits.set_supports_heat_mode(true);
-        traits.set_supports_cool_mode(true);
-        traits.set_supports_dry_mode(true);
-        traits.set_supports_fan_only_mode(true);
-        traits.set_supports_fan_mode_on(false);
-        traits.set_supports_fan_mode_off(false);
-        traits.set_supports_fan_mode_auto(true);
-        traits.set_supports_fan_mode_low(true);
-        traits.set_supports_fan_mode_medium(true);
-        traits.set_supports_fan_mode_middle(true);
-        traits.set_supports_fan_mode_high(true);
-        traits.set_supports_fan_mode_focus(false);
-        traits.set_supports_fan_mode_diffuse(false);
+
+
+        traits.set_supports_action(true);
+
+        traits.set_supported_modes(
+        {
+            climate::CLIMATE_MODE_OFF,
+            climate::CLIMATE_MODE_HEAT_COOL,
+            climate::CLIMATE_MODE_COOL,
+            climate::CLIMATE_MODE_HEAT,
+            climate::CLIMATE_MODE_FAN_ONLY,
+            climate::CLIMATE_MODE_DRY
+        });
+
+        traits.set_supported_fan_modes(
+        {
+            climate::CLIMATE_FAN_AUTO,
+            climate::CLIMATE_FAN_LOW,
+            climate::CLIMATE_FAN_MEDIUM,
+            climate::CLIMATE_FAN_HIGH,
+            climate::CLIMATE_FAN_MIDDLE,
+        });
+
+        traits.set_supported_swing_modes(
+        {
+            climate::CLIMATE_SWING_OFF,
+            climate::CLIMATE_SWING_BOTH,
+            climate::CLIMATE_SWING_VERTICAL,
+            climate::CLIMATE_SWING_HORIZONTAL
+        });
+
         traits.set_visual_min_temperature(MIN_SET_TEMPERATURE);
         traits.set_visual_max_temperature(MAX_SET_TEMPERATURE);
         traits.set_visual_temperature_step(STEP_TEMPERATURE);
         traits.set_supports_current_temperature(true);
-        traits.set_supports_swing_mode_off(true);
-        traits.set_supports_swing_mode_both(true);
-        traits.set_supports_swing_mode_vertical(true);
-        traits.set_supports_swing_mode_horizontal(true);
+        traits.set_supports_two_point_target_temperature(false);
 
         return traits;
     }
@@ -192,7 +205,7 @@ public:
                     mode = CLIMATE_MODE_FAN_ONLY;
                     break;
                 default:
-                    mode = CLIMATE_MODE_AUTO;
+                    mode = CLIMATE_MODE_HEAT_COOL;
             }
 
             if ( data[SWING_POS] & ( 1 << SILENT_MODE_BIT_ON )) {
@@ -271,7 +284,7 @@ public:
                     data[FAN_SPEED] = FAN_MIDDLE; // set fan speed for change work mode
                     data[MODE] = MODE_FAN_ONLY;
                     break;
-                case CLIMATE_MODE_AUTO:
+                case CLIMATE_MODE_HEAT_COOL:
                     data[POWER] |= (1 << POWER_BIT_ON);
                     data[MODE] = MODE_SMART;
                     break;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
  # ESP Haier
+ ## for dev version ESPhome only!!!
  
  ESP Haier is a project to use a ESP8266 (I did not test with ESP32) to control Haier Air Conditioner with wifi module supoort with ESPHome and Home Assisant.
  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
  # ESP Haier
- ## for dev version ESPhome only!!!
+ ## for > 1.2.0 version ESPhome
  
  ESP Haier is a project to use a ESP8266 (I did not test with ESP32) to control Haier Air Conditioner with wifi module supoort with ESPHome and Home Assisant.
  

--- a/esphaier.yaml
+++ b/esphaier.yaml
@@ -5,16 +5,34 @@ esphome:
   includes:
     - Haier.h
 
+# Set statul led for Wemos D1 mini
+status_led:
+  pin: GPIO2
 
-logger:
-  level: DEBUG
-  baud_rate: 0 #Important. You can't use serial port
-  
-  
 wifi:
   ssid: ""
   password: ""
 
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "Haier_wifi"
+    password: "Haier_wifi"
+
+captive_portal:
+
+# Enable web server (can be disabled)
+web_server:
+  port: 80
+
+time:
+  - platform: sntp
+    id: sntp_time
+    timezone: "Asia/ Yekaterinburg"
+
+# Enable logging
+logger:
+  level: DEBUG
+  baud_rate: 0 #Important. You can't use serial port
 
 # Enable Home Assistant API
 api:
@@ -23,10 +41,6 @@ api:
 ota:
   password: ""
 
-
-
-  
-  
 climate:
   - platform: custom
     lambda: |-


### PR DESCRIPTION
You change mode on the unit and the mini split works as it should, but shows off in parentheses but then the mode next to it.
![6C50F1A7-3D09-4866-93ED-04A3179D16B1](https://user-images.githubusercontent.com/35973261/130367220-85a561f7-eb44-4c2e-b652-49ccf0af950c.png)
![55E16CAA-1515-4E31-9E1F-45D68E02F89C](https://user-images.githubusercontent.com/35973261/130367221-70f264c8-6143-412a-a89c-b12e4627ee04.png)
![9CDBB19D-7E15-4138-AD0C-312390F321AA](https://user-images.githubusercontent.com/35973261/130367222-a87684de-0884-4068-822a-70cfce47fb77.png)
