### PR TITLE
Update Haier.h

### DIFF
--- a/Haier.h
+++ b/Haier.h
@@ -153,7 +153,7 @@ public:
         target_temperature = data[SET_TEMPERATURE] + 16;
 
 
-        if (data[POWER] == 0 || data[POWER] == 8 ) {
+        if (data[POWER] == 0 || data[POWER] == 8 || data[POWER] == 40 ) {
             mode = CLIMATE_MODE_OFF;
 
         } else {


### PR DESCRIPTION
string 156 - added power off state correct read "data[POWER] == 40" in case of temperature with 0.5 degrees is set
tested on my Aircon - works fine.

I've made an issue request about it
https://github.com/MiguelAngelLV/esphaier/issues/20#issuecomment-1193277093
Would really appreciate if you can help with 0.5 degrees temperature adding.
It's needed to add powerstate command output "41" instead of "9" when the temperature with a half set.